### PR TITLE
Do not throw if request is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,10 @@ module.exports = (registry, config = {}) => {
 
     if (ignoreRoute(request, server)) return
 
-    const { summaryTimer, histogramTimer } = timers.get(request)
+    const requestTimers = timers.get(request)
+    if (!requestTimers) return
+
+    const { summaryTimer, histogramTimer } = requestTimers
     timers.delete(request)
 
     if (ignore(request, response, server)) return

--- a/test/helper.js
+++ b/test/helper.js
@@ -15,6 +15,9 @@ function createHttpServer (t) {
       if (req.url === '/2s') {
         await sleep(2000)
       }
+      if (req.url === '/10s') {
+        await sleep(10000)
+      }
       res.end('Hello World\n')
     }
   )


### PR DESCRIPTION
This is needed for the case when the time line is the following:

- server receives a request
- server starts collecting metrics
- server sends a response
